### PR TITLE
Fixed issue preventing decoders from resolving using other custom decoders

### DIFF
--- a/JDeck/Serialization.fs
+++ b/JDeck/Serialization.fs
@@ -32,18 +32,18 @@ type private JDeckConverter<'T>(?encoder: Encoder<'T>, ?decoder: Decoder<'T>) =
 
 module Codec =
   let useEncoder (encoder: Encoder<'T>) (options: JsonSerializerOptions) =
-    options.Converters.Add(JDeckConverter<'T>(encoder = encoder))
+    options.Converters.Insert(0, JDeckConverter<'T>(encoder = encoder))
     options
 
   let useDecoder (decoder: Decoder<'T>) (options: JsonSerializerOptions) =
-    options.Converters.Add(JDeckConverter<'T>(decoder = decoder))
+    options.Converters.Insert(0, JDeckConverter<'T>(decoder = decoder))
     options
 
   let useCodec
     (encoder: Encoder<'T>, decoder: Decoder<'T>)
     (options: JsonSerializerOptions)
     =
-    options.Converters.Add(
+    options.Converters.Insert(0, 
       JDeckConverter<'T>(encoder = encoder, decoder = decoder)
     )
 


### PR DESCRIPTION
Changing from the original `Converters.Insert` to `Converters.Add` breaks decoders (and I'm assuming encoders as well) that rely on other custom decoders. 

I have another related issue as well, but I think this fix is a prerequisite, so I will create a separate issue for it after this PR.